### PR TITLE
Matlab Toolbox dependencies in Homer3

### DIFF
--- a/Utils/ffpath.m
+++ b/Utils/ffpath.m
@@ -1,0 +1,54 @@
+function pth = ffpath(fname)
+%   FFPATH    Find file path
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% The function browses very fast current directory and directories known in 
+% 'matlabpath' and the system variable 'path'. It searches for the file,
+% name of which is in the input argument 'fname'. If a directory is found, 
+% the output argument pth is filled by path to the file name from the input
+% argument, otherwise pth is empty.
+% File names should have their extensions, but MATLAB m-files.
+% 
+% Arguments:
+%   fname   file name 
+%   pth     path to the fname
+%
+% Examples:
+%   pth = ffpath('gswin32c.exe')
+%   pth =
+%   c:\Program Files\gs\gs8.60\bin\
+%
+%   pth = ffpath('hgrc')
+%   pth =
+%   C:\PROGRA~1\MATLAB\R2006b\toolbox\local
+
+% Miroslav Balda
+% miroslav AT balda DOT cz
+% 2008-12-15    v 0.1   only for system variable 'path'
+% 2008-12-20    v 1.0   for both 'path' and 'matlabpath'
+
+if nargin<1
+    error('The function requires one input argument (file name)')
+end
+pth = pwd;
+if exist([pth '/' fname],'file')
+    return
+end % fname found in current dir
+
+tp = matlabpath;
+t  = 0;
+if isunix() | ismac()
+    I = [t, findstr(tp,':'), length(tp)+1];
+elseif ispc()
+    I = [t, findstr(tp,';'), length(tp)+1];
+end    
+for k = 1:length(I)-1               %   search in path's directories
+    pth = tp(I(k)+1:I(k+1)-1);
+    % fprintf('%s\n', [pth '/' fname]);
+    if exist([pth '/' fname],'file')
+        return;
+    end
+end
+[status,tp] = system('path');
+t = 5;
+pth = '';
+

--- a/Utils/strcellfind.m
+++ b/Utils/strcellfind.m
@@ -1,0 +1,16 @@
+function [b,idxs]  = strcellfind(strs, s)
+
+b = false;
+
+r = strfind(strs, s);
+
+idxs=[];
+kk=1;
+for ii=1:length(r)
+    if ~isempty(r{ii})
+        b = true;
+        idxs(kk) = ii;
+        kk=kk+1;
+    end
+end
+

--- a/checkToolboxes.m
+++ b/checkToolboxes.m
@@ -1,0 +1,40 @@
+function r = checkToolboxes(toolboxes, app)
+
+r = true;
+
+if ~exist('app','var')
+    app = '';
+end
+
+missing = [];
+kk = 1;
+for ii=1:length(toolboxes)
+    if ~isToolboxAvailable(toolboxes{ii})
+        missing(kk) = ii;
+        kk=kk+1;
+    end
+end
+
+if ~isempty(missing)
+    msg1 = sprintf('WARNING: The following matlab toolboxes have not been installed:\n');
+    msg2 = sprintf('\n');
+    msg3 = '';
+    msg4 = sprintf('\n');
+    if isempty(app)
+        msg5 = sprintf('SOME FUNCTIONS MAY NOT WORK PROPERLY.');
+    else
+        msg5 = sprintf('SOME FUNCTIONS IN %s MAY NOT WORK PROPERLY.', app);
+    end
+    for jj=1:length(missing)
+        if isempty(msg3)
+            msg3 = sprintf('%s\n', toolboxes{missing(jj)});
+        else
+            msg3 = sprintf('%s%s\n', msg3, toolboxes{missing(jj)});
+        end
+    end
+    
+    msg = [msg1, msg2, msg3, msg4, msg5];
+    menu(msg, 'OK');
+    r = false;
+end
+

--- a/checkToolboxes_Homer3.m
+++ b/checkToolboxes_Homer3.m
@@ -1,0 +1,107 @@
+function [r, toolboxes] = checkToolboxes_Homer3()
+
+toolboxes = {};
+
+header{1} = sprintf('==============================================\n');
+header{2} = sprintf('List of required toolboxes for Homer3:\n');
+header{3} = sprintf('==============================================\n');
+
+% Check for presence of file which already has all the toolboxes
+r = true;
+filename = getToolboxListFilename('Homer3');
+if exist(filename,'file')==2
+    fid = fopen(filename);
+    if(fid > 0)
+        for ii=1:length(header)
+            fprintf(header{ii});
+        end
+        kk=1;
+        while 1
+            line = fgetl(fid);
+            if line==-1
+                break;
+            end
+            toolboxes{kk} = line;
+            fprintf('%s\n', toolboxes{kk});
+            kk=kk+1;
+        end
+        fclose(fid);
+        fprintf('\n');
+        r = checkToolboxes(toolboxes, 'Homer3');
+        return;
+    end
+end
+
+if verLessThan('matlab','8.3')
+    r = 4;
+    return;
+end
+
+msg{1} = sprintf('Unable to find matching toolbox list for the current Matlab release.\n');
+msg{2} = sprintf('Do you want to run toolbox discovery to determine which toolboxes are required?\n');
+msg{3} = sprintf('It takes 5-10 minutes.\n');
+q = menu([msg{:}], 'YES','NO');
+if q==2
+    r = 3;
+    return;
+end
+
+exclList = {};
+
+% Change curr folder to Homer3
+currdir = pwd;
+cd(strcat(pwd,'\Utils'));
+if ~exist('dirnameApp','var') || isempty(dirnameApp)
+    dirnameApp = ffpath('setpaths.m');
+end
+if dirnameApp(length(dirnameApp))~='/' && dirnameApp(length(dirnameApp))~='\'
+    dirnameApp(length(dirnameApp)+1)='/';
+end
+cd(dirnameApp);
+
+% Find all the .m files for Homer3
+files = findDotMFiles('.', exclList);
+nFiles = length(files);
+
+hwait = waitbar(0, sprintf('Checking toolboxes for %d source files', nFiles));
+for ii=1:nFiles
+    
+    fprintf('Checking ''%s'' for required toolboxes ...\n', files{ii});
+    
+    % Searching for Homer3 toolboxes takes a long time, so it was done
+    % beforehand and is already included in toolboxes.
+    [~,f,~] = fileparts(files{ii});
+    if strcmp(f, 'Homer3')
+        continue;
+    end
+    
+    [~, q] = matlab.codetools.requiredFilesAndProducts(files{ii});
+    for jj=1:length(q)
+        if ~strcmpi(q(jj).Name, 'MATLAB')
+            if ~strcellfind(toolboxes, q(jj).Name)
+                fprintf('Adding ''%s'' to list of required toolboxes\n', q(jj).Name);
+                toolboxes{end+1} = q(jj).Name;
+            end
+        end
+    end
+    waitbar(ii/length(files), hwait, sprintf('Checked %d of %d files', ii, nFiles));
+end
+close(hwait);
+fprintf('\n');
+
+cd(currdir);
+
+fid = fopen(filename,'wt');
+for ii=1:length(header)
+    fprintf(header{ii});
+end
+for jj=1:length(toolboxes)
+    line = sprintf('%s\n', toolboxes{jj});
+    fprintf(fid, line);
+    fprintf(line);
+end
+fprintf('\n');
+fclose(fid);
+
+r = checkToolboxes(toolboxes, 'Homer3');
+

--- a/getToolboxListFilename.m
+++ b/getToolboxListFilename.m
@@ -1,0 +1,15 @@
+function filenameFinal = getToolboxListFilename(appName)
+
+filenameFinal = '';
+        
+if isempty(filenameFinal)
+    filename = sprintf('./toolboxesRequired_%s.txt', appName);
+    if exist(filename, 'file')==2
+        filenameFinal = filename;
+    end
+end
+
+filenameFinal = filename;
+
+end
+

--- a/setpaths_proprietary.m
+++ b/setpaths_proprietary.m
@@ -1,5 +1,19 @@
 function setpaths_proprietary(options)
 
+r = checkToolboxes_Homer3();
+
+fprintf('\n');
+if all(r==1)
+    fprintf('All required toolboxes are installed.\n');
+elseif ismember(3, r)
+    fprintf('Unable to verify if all required toolboxes are installed ...\n');
+elseif ismember(4, r)
+    fprintf('Unable to verify if all required toolboxes are installed with older Matlab release...\n');
+else
+    fprintf('Some required toolboxes are missing...\n');
+end
+
+pause(2);
 % Check if wavelet data db2.mat is available in toolbox.
 % If no then create it from known data
 fullpathhomer3 = fileparts(which('Homer3.m'));

--- a/toolboxesRequired_Homer3.txt
+++ b/toolboxesRequired_Homer3.txt
@@ -1,0 +1,6 @@
+Signal Processing Toolbox
+Image Processing Toolbox
+Curve Fitting Toolbox
+Statistics and Machine Learning Toolbox
+Wavelet Toolbox
+Symbolic Math Toolbox


### PR DESCRIPTION
Notifies user of MATLAB toolbox dependencies like during setpaths process. If user is missing a toolbox, window pops up that warns user that a specific toolbox is missing and that certain features might not work fully.