### PR TITLE
Manual time point exclusion fixes

### DIFF
--- a/DataTree/ProcStream/ProcInputClass.m
+++ b/DataTree/ProcStream/ProcInputClass.m
@@ -169,11 +169,13 @@ classdef ProcInputClass < handle
         
         % ----------------------------------------------------------------------------------
         function val = GetTincMan(obj, iBlk)
-            val = {};
+            val = [];
             if ~exist('iBlk','var') || isempty(iBlk)
-                val = obj.tIncMan;
+                val = obj.tIncMan{1};
             elseif ~isempty(obj.tIncMan)
                 val = obj.tIncMan{iBlk};
+            else  % tInc is invalid or unpopulated
+                val = [];
             end
         end
        

--- a/DataTree/ProcStream/ProcStreamClass.m
+++ b/DataTree/ProcStream/ProcStreamClass.m
@@ -1214,9 +1214,9 @@ classdef ProcStreamClass < handle
         % ----------------------------------------------------------------------------------
         function tIncMan = GetTincMan(obj, iBlk)
             if ~exist('iBlk','var')
-                iBlk = [];
+                iBlk = 1;
             end
-            tIncMan = obj.input.GetVar('tIncMan', iBlk);
+            tIncMan = obj.input.GetTincMan(iBlk);
         end
         
 

--- a/DataTree/RunClass.m
+++ b/DataTree/RunClass.m
@@ -511,6 +511,10 @@ classdef RunClass < TreeNodeClass
                 iBlk = 1;
             end
             tIncMan = obj.procStream.input.GetTincMan(iBlk);
+            if isempty(tIncMan)  % If the Tinc array is unitialized TODO find a more sensical place to do this
+               obj.InitTincMan();
+               tIncMan = obj.procStream.input.GetTincMan(iBlk);
+            end
         end
         
         
@@ -534,7 +538,7 @@ classdef RunClass < TreeNodeClass
         
         % ----------------------------------------------------------------------------------
         function InitTincMan(obj)
-            iBlk = 1;
+            iBlk = 1;  % TODO implement multiple data blocks
             while 1
                 t = obj.acquired.GetTime(iBlk);
                 if isempty(t)
@@ -544,8 +548,7 @@ classdef RunClass < TreeNodeClass
                 obj.procStream.SetTincMan(tIncMan, iBlk);
                 iBlk = iBlk+1;
             end
-        end
-                
+        end              
     end        % Public Set/Get methods
     
     

--- a/MainGUI/DisplayExcludedTime.m
+++ b/MainGUI/DisplayExcludedTime.m
@@ -48,7 +48,7 @@ for iBlk = iDataBlks
         end
         col = setColor(mode, ii);
         t = maingui.dataTree.currElem.GetTime(iBlk);
-        [h, tPtsExclTot] = drawPatches(t, tInc(:,kk), tPtsExclTot, col, handles);        
+        [h, tPtsExclTot] = drawPatches(t, tInc, tPtsExclTot, col, handles);        
         if strcmp(mode,'manual')
             for jj=1:length(h)
                 set(h(jj), 'ButtonDownFcn', sprintf('PatchCallback(%d)',jj));

--- a/MainGUI/MainGUI.m
+++ b/MainGUI/MainGUI.m
@@ -429,8 +429,13 @@ t = tic;
 % Set the display status to pending. In order to avoid redisplaying 
 % in a single callback thread in functions called from here which 
 % also call DisplayData
-maingui.dataTree.CalcCurrElem();
-
+try
+    maingui.dataTree.CalcCurrElem();
+catch
+    MainGUI_EnableDisableGUI(handles,'on');
+    return
+end
+    
 % Restore original selection listboxGroupTree
 set(handles.listboxGroupTree, 'value',val0);
 
@@ -1518,10 +1523,6 @@ for iBlk=1:iDataBlks
     % Reject all stims that fall within the excluded time
     maingui.dataTree.currElem.StimReject(t, iBlk);
 
-end
-
-if isempty(out.format)
-    return;
 end
 
 % Display excluded time and rejected stims


### PR DESCRIPTION
This has been requested by a user and previously it did not work. Essentially this adds a disable stim feature to MainGUI. Individual channel disabling is not implemented here, nor is full support for data blocks.