### PR TITLE
Procstream order checking

### DIFF
--- a/DataTree/ProcStream/ArgClass.m
+++ b/DataTree/ProcStream/ArgClass.m
@@ -59,14 +59,15 @@ classdef ArgClass < matlab.mixin.Copyable
             if size(args,1) > 1
                 args = args';
             end
-            if args{1}(1)=='[' || args{1}(1)=='('
-                args{1}(1) = '';
-            end
-            if args{end}(end)==']'
-                args{end}(end) = '';
+            if size(args, 1) > 0
+                if args{1}(1)=='[' || args{1}(1)=='('
+                    args{1}(1) = '';
+                end
+                if args{end}(end)==']'
+                    args{end}(end) = '';
+                end 
             end
         end        
-        
     end
 end
 

--- a/DataTree/ProcStream/FuncCallClass.m
+++ b/DataTree/ProcStream/FuncCallClass.m
@@ -184,6 +184,20 @@ classdef FuncCallClass < handle
         
         
         
+        % ------------------------------------------------------------
+        function inputs = GetInputs(obj)
+           inputs = obj.argIn.Extract(); 
+        end
+        
+        
+        
+        % ------------------------------------------------------------
+        function outputs = GetOutputs(obj)
+           outputs = obj.argOut.Extract(); 
+        end
+            
+        
+        
         % ----------------------------------------------------------------------------------
         function SetUsageName(obj, usagename)
             if nargin<2

--- a/DataTree/ProcStream/ProcInputClass.m
+++ b/DataTree/ProcStream/ProcInputClass.m
@@ -163,11 +163,11 @@ classdef ProcInputClass < handle
         function inputs = GetProcInputs(obj)
             % Get name of each property available from GetVars
             inputs = {};
-            p = properties(obj);
+            p = propnames(obj);
             % Get name of each property
             for i = 1:size(p)
                inputs{end+1} = p{i}; %#ok<AGROW>
-               pi = properties(obj.(p{i}));
+               pi = propnames(obj.(p{i}));
                % Get name of each sub-property (properties of misc, acquired)
                for j = 1:size(pi)
                   inputs{end+1} = pi{j};  %#ok<AGROW>

--- a/DataTree/ProcStream/ProcInputClass.m
+++ b/DataTree/ProcStream/ProcInputClass.m
@@ -159,6 +159,23 @@ classdef ProcInputClass < handle
             b = obj.acquired.DataModified();
         end
         
+        % ----------------------------------------------------------------------------------
+        function inputs = GetProcInputs(obj)
+            % Get name of each property available from GetVars
+            inputs = {};
+            p = properties(obj);
+            % Get name of each property
+            for i = 1:size(p)
+               inputs{end+1} = p{i}; %#ok<AGROW>
+               pi = properties(obj.(p{i}));
+               % Get name of each sub-property (properties of misc, acquired)
+               for j = 1:size(pi)
+                  inputs{end+1} = pi{j};  %#ok<AGROW>
+               end
+            end
+            
+        end
+        
     end
         
     

--- a/DataTree/ProcStream/ProcStreamClass.m
+++ b/DataTree/ProcStream/ProcStreamClass.m
@@ -551,7 +551,7 @@ classdef ProcStreamClass < handle
             % Processing stream begins with inputs available
             available = obj.input.GetProcInputs();
             % Inputs which are usually optional or defined elsewhere
-            extras = {'iRun' 'iSubj' 'iGroup' 'mlActAuto', 'tIncAuto', 'Aaux', 'rcMap'}
+            extras = {'iRun' 'iSubj' 'iGroup' 'mlActAuto', 'tIncAuto', 'Aaux', 'rcMap'};
             available = [available, extras];
             
             % For all fcalls
@@ -562,12 +562,16 @@ classdef ProcStreamClass < handle
                 % Check that each input is available
                 for j = 1:length(inputs)
                     if ~any(strcmp(available, inputs{j}))
-                       fn_error = i;
+                       fn_error = obj.fcalls(i);
                        missing_args{end+1} = inputs{j};
                     end
                 end
                 
-                if fn_error > 0
+                if isa(fn_error, 'FuncCallClass')
+                    entry = obj.reg.GetEntryByName(fn_error.name);
+                    if isfield(entry.help.sections, 'prerequisites')
+                       prereqs = strtrim(entry.help.sections.prerequisites.str); 
+                    end
                    return; 
                 end
                 

--- a/DataTree/ProcStream/ProcStreamClass.m
+++ b/DataTree/ProcStream/ProcStreamClass.m
@@ -550,6 +550,9 @@ classdef ProcStreamClass < handle
             
             % Processing stream begins with inputs available
             available = obj.input.GetProcInputs();
+            % Inputs which are usually optional or defined elsewhere
+            extras = {'iRun' 'iSubj' 'iGroup' 'mlActAuto', 'tIncAuto'}
+            available = [available, extras];
             
             % For all fcalls
             for i = 1:length(obj.fcalls)

--- a/DataTree/ProcStream/ProcStreamClass.m
+++ b/DataTree/ProcStream/ProcStreamClass.m
@@ -536,7 +536,46 @@ classdef ProcStreamClass < handle
             delete(obj.fcalls);
             obj.fcalls = FuncCallClass().empty();
         end
-                        
+        
+        
+        % -----------------------------------------------------------------
+        function [fn_error, missing_args, prereqs] = Check(obj)
+            % Returns index of processing stream function which is missing
+            % an argument, and a cell array of the missing arguments. 
+            % fn_error is 0 if there are no errors.
+            
+            missing_args = {};
+            fn_error = 0;
+            prereqs = '';
+            
+            % Processing stream begins with inputs available
+            available = obj.input.GetProcInputs();
+            
+            % For all fcalls
+            for i = 1:length(obj.fcalls)
+                
+                inputs = obj.fcalls(i).GetInputs();
+                
+                % Check that each input is available
+                for j = 1:length(inputs)
+                    if ~any(strcmp(available, inputs{j}))
+                       fn_error = i;
+                       missing_args{end+1} = inputs{j};
+                    end
+                end
+                
+                if fn_error > 0
+                   return; 
+                end
+                
+                % Add outputs of the function to available list
+                outputs = obj.fcalls(i).GetOutputs();
+                for j = 1:length(outputs)
+                   available{end + 1} = outputs{j}; 
+                end
+            end
+        end
+                
     end
     
     

--- a/DataTree/ProcStream/ProcStreamClass.m
+++ b/DataTree/ProcStream/ProcStreamClass.m
@@ -551,7 +551,7 @@ classdef ProcStreamClass < handle
             % Processing stream begins with inputs available
             available = obj.input.GetProcInputs();
             % Inputs which are usually optional or defined elsewhere
-            extras = {'iRun' 'iSubj' 'iGroup' 'mlActAuto', 'tIncAuto'}
+            extras = {'iRun' 'iSubj' 'iGroup' 'mlActAuto', 'tIncAuto', 'Aaux', 'rcMap'}
             available = [available, extras];
             
             % For all fcalls

--- a/FuncRegistry/RegistriesClass.m
+++ b/FuncRegistry/RegistriesClass.m
@@ -363,6 +363,19 @@ classdef RegistriesClass < handle
             b = true;
         end
         
+
+        % ----------------------------------------------------------------------------------
+        function entry = GetEntryByName(obj, entry_name)
+            entry = [];
+            for i=1:size(obj.funcReg, 2)
+                for j=1:size(obj.funcReg(i).entries, 2)
+                    if strcmp(obj.funcReg(i).entries(j).name, entry_name) || strcmp(obj.funcReg(i).entries(j).uiname, entry_name)
+                        entry = obj.funcReg(i).entries(j);
+                    end
+                end
+            end
+        end
+        
     end
         
 end

--- a/FuncRegistry/UserFunctions/hmrR_BandpassFilt.m
+++ b/FuncRegistry/UserFunctions/hmrR_BandpassFilt.m
@@ -24,6 +24,9 @@
 % PARAMETERS:
 % hpf: [0.010]
 % lpf: [0.500]
+%
+% PREREQUISITES:
+% Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
 
 function [data2, ylpf] = hmrR_BandpassFilt( data, hpf, lpf )
 if isa(data, 'DataClass')

--- a/FuncRegistry/UserFunctions/hmrR_BlockAvg.m
+++ b/FuncRegistry/UserFunctions/hmrR_BlockAvg.m
@@ -30,7 +30,10 @@
 % PARAMETERS:
 % trange: [-2.0, 20.0]
 %
-
+% PREREQUISITES:
+% For the Block_Average_on_Concentration_Data Usage Option, use Delta_OD_to_Conc: dc = hmrR_OD2Conc( dod, probe, ppf )
+% For the Block_Average_on_Delta_OD_Data Usage Option, use Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
+%
 function [data_avg, data_std, nTrials, data_sum2, yTrials] = hmrR_BlockAvg( data, stim, trange )
 
 % Initialize outputs;

--- a/FuncRegistry/UserFunctions/hmrR_GLM.m
+++ b/FuncRegistry/UserFunctions/hmrR_GLM.m
@@ -99,6 +99,9 @@
 % driftOrder: 3
 %
 %
+% PREREQUISITES:
+% Delta_OD_to_Conc: dc = hmrR_OD2Conc( dod, probe, ppf )
+%
 function [data_yavg, data_yavgstd, nTrials, data_ynew, data_yresid, data_ysum2, beta_blks, yR_blks] = ...
     hmrR_GLM(data_y, stim, probe, mlActAuto, Aaux, tIncAuto, rcMap, trange, glmSolveMethod, idxBasis, paramsBasis, rhoSD_ssThresh, flagNuisanceRMethod, driftOrder)
 
@@ -354,7 +357,6 @@ for iBlk=1:length(data_y)
                 end
                 clmn = clmn(1:nT);
                 dA(:,iC,iConc) = clmn;
-                beta_label{b + (iCond-1)*nB} = ['Cond' num2str(iCond)]; 
             end
         end
     end
@@ -404,42 +406,14 @@ for iBlk=1:length(data_y)
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     % Final design matrix
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    dummy = size(beta_label,2);
-
     switch flagNuisanceRMethod
         case {0,1,2} % short separation
             for iConc=1:2
                 A(:,:,iConc)=[dA(:,:,iConc) xDrift Aaux Amotion];
-                
-                if iConc == 1 
-                    for ixDrift = 1:size(xDrift,2)
-                        beta_label{ixDrift + dummy} = ['xDrift'];
-                    end
-                    dummy = size(beta_label,2);
-                    for iAaux = 1:size(Aaux,2)
-                        beta_label{iAaux + dummy} = ['Aux'];
-                    end
-                    dummy = size(beta_label,2);
-                    for iAmotion = 1:size(Amotion,2)
-                        beta_label{ixDrift + dummy} = ['Motion'];
-                    end
-                end
-                
             end
         case 3 % tCCA regressor design matrix without Aaux (will be put in in the loop below)
             for iConc=1:2
                 A(:,:,iConc)=[dA(:,:,iConc) xDrift Amotion];
-                
-                if iConc == 1 
-                    for ixDrift = 1:size(xDrift,2) 
-                        beta_label{ixDrift + dummy} = ['Drift'];
-                    end
-                    dummy = size(beta_label,2);
-                    for iAmotion = 1:size(Amotion,2)
-                        beta_label{ixDrift + dummy} = ['Motion'];
-                    end
-                end 
-                
             end
     end
     
@@ -497,64 +471,24 @@ for iBlk=1:length(data_y)
                 % lstML = find(iNearestSS==mlSSlst(iSS));
                 Ass = y(:,conc,mlSSlst(iSS));
                 At = [A(:,:,conc) Ass];
-                
-                if iSS == 1 && conc == 1
-                    dummy = size(beta_label,2); 
-                    for iAss = 1:size(Ass,2)
-                        beta_label{iAss + dummy} = ['ShortSep'];
-                    end 
-                end
-                
             elseif flagNuisanceRMethod==1
                 lstML = find(iNearestSS(:,conc)==mlSSlst(iSS) & mlAct(lstMLtmp)==1);
                 % lstML = find(iNearestSS(:,conc)==mlSSlst(iSS));
                 Ass = y(:,conc,mlSSlst(iSS));
                 At = [A(:,:,conc) Ass];
-                
-                if iSS == 1 && conc == 1
-                    dummy = size(beta_label,2);
-                    for iAss = 1:size(Ass,2)
-                        beta_label{iAss + dummy} = ['ShortSep'];
-                    end
-                end
-                
             elseif flagNuisanceRMethod==2
                 lstML = lstMLtmp(find(mlAct(lstMLtmp)==1));
                 % lstML = 1:size(y,3);
                 Ass = mean(y(:,conc,lstSS),3);
                 At = [A(:,:,conc) Ass];
-                
-                if iSS == 1 && conc == 1
-                    dummy = size(beta_label,2);
-                    for iAss = 1:size(Ass,2)
-                        beta_label{iAss + dummy} = ['ShortSep'];
-                    end
-                end
-                
             elseif flagNuisanceRMethod==3
                 if ischar(rcMap{iBlk}) % no channel map: use all tCCA regressors for one group of all channels
                     lstML = lstMLtmp(find(mlAct(lstMLtmp)==1));
                     At = [A(:,:,conc) Aaux];
-                    
-                    if iSS == 1 && conc == 1
-                        dummy = size(beta_label,2);
-                        for iAaux = 1:size(Aaux,2)
-                            beta_label{iAaux + dummy} = ['Aux'];
-                        end
-                    end
-                    
                 elseif iscell(rcMap{iBlk}) % channel map: each single regressor corresponds to one channel (nCH groups)
                     lstML = lstMLtmp(find(mlAct(rcMap{iBlk}{conc,iSS})==1));
                     Atcca = Aaux{iBlk}(:,rcMap{conc,iSS});
                     At = [A(:,:,conc) Atcca];
-                    
-                    if iSS == 1 && conc == 1
-                        dummy = size(beta_label,2);
-                        for iAtcca = 1:size(Atcca,2)
-                            beta_label{iAtcca + dummy} = ['tCCA regressor'];
-                        end
-                    end
-                    
                 end
             end
             
@@ -642,12 +576,11 @@ for iBlk=1:length(data_y)
                 if glmSolveMethod==1 %  OLS  ~flagUseTed
                     pAinvAinvD = diag(pinvA*pinvA');
                     yest(:,lstML,conc) = At * foo(:,lstML,conc);
-                    yvar(1,lstML,conc) = sum((squeeze(y(:,conc,lstML))-yest(:,lstML,conc)).^2)./(size(y,1)-1); % check this against eq(53) in Ye2009
+                    yvar(1,lstML,conc) = std(squeeze(y(:,conc,lstML))-yest(:,lstML,conc),[],1).^2; % check this against eq(53) in Ye2009
                     for iCh = 1:length(lstML)
                         bvar(:,lstML(iCh),conc) = yvar(1,lstML(iCh),conc) * pAinvAinvD;
-                        tval(:,lstML(iCh),conc) =  foo(:,lstML(iCh),conc)./sqrt(bvar(:,lstML(iCh),conc)); 
-                        pval(:,lstML(iCh),conc) = 1-tcdf(abs(tval(:,lstML(iCh),conc)),(size(y,1)-1));   
                         for iCond=1:nCond
+                            %                yavgstd(:,lstML(iCh),conc,iCond) = diag(tbasis*diag(bvar([1:nB]+(iCond-1)*nB,lstML(iCh),conc))*tbasis').^0.5;
                             if size(tbasis,3)==1
                                 yavgstd(:,lstML(iCh),conc,iCond) = diag(tbasis*diag(bvar([1:nB]+(iCond-1)*nB,lstML(iCh),conc))*tbasis').^0.5;
                             else
@@ -755,11 +688,6 @@ for iBlk=1:length(data_y)
     % Set other data blocks
     beta_blks{iBlk} = beta;
     yR_blks{iBlk}   = yR;
-    
-    % stats struct
-    hmrstats.beta_label = beta_label; % 
-    hmrstats.tval = tval;
-    hmrstats.pval = pval; 
 
 end
 

--- a/FuncRegistry/UserFunctions/hmrR_MotionArtifact.m
+++ b/FuncRegistry/UserFunctions/hmrR_MotionArtifact.m
@@ -52,6 +52,9 @@
 % STDEVthresh: 50.0
 % AMPthresh: 5.0
 %
+% PREREQUISITES:
+% Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity ), Prune_Channels: mlActAuto = hmrR_PruneChannels(data, probe, mlActMan, tIncMan, dRange, SNRthresh, SDrange, reset)
+%
 % LOG:
 % K. Perdue
 % kperdue@nmr.mgh.harvard.edu

--- a/FuncRegistry/UserFunctions/hmrR_MotionArtifactByChannel.m
+++ b/FuncRegistry/UserFunctions/hmrR_MotionArtifactByChannel.m
@@ -50,6 +50,9 @@
 % STDEVthresh: 50.0
 % AMPthresh: 5.00
 %
+% PREREQUISITES:
+% Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
+%
 % LOG:
 % K. Perdue
 % kperdue@nmr.mgh.harvard.edu

--- a/FuncRegistry/UserFunctions/hmrR_MotionCorrectCbsi.m
+++ b/FuncRegistry/UserFunctions/hmrR_MotionCorrectCbsi.m
@@ -27,6 +27,9 @@
 % PARAMETERS:
 % turnon: 1
 %
+% PREREQUISITES:
+% Delta_OD_to_Conc: dc = hmrR_OD2Conc( dod, probe, ppf )
+%
 % LOG:
 % created 10-17-2012, S. Brigadoi
 %

--- a/FuncRegistry/UserFunctions/hmrR_MotionCorrectPCA.m
+++ b/FuncRegistry/UserFunctions/hmrR_MotionCorrectPCA.m
@@ -32,6 +32,9 @@
 % PARAMETERS:
 % nSV: 0.0
 %
+% PREREQUISITES:
+% Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
+%
 function [data_dN, svs, nSV] = hmrR_MotionCorrectPCA(data_d,  mlActMan, tIncMan, nSV)
 
 % Init output 

--- a/FuncRegistry/UserFunctions/hmrR_MotionCorrectPCArecurse.m
+++ b/FuncRegistry/UserFunctions/hmrR_MotionCorrectPCArecurse.m
@@ -63,6 +63,9 @@
 % maxIter: 5 
 % turnon: 1
 %
+% PREREQUISITES:
+% Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
+%
 function [data_dN, tInc, svs, nSV, tInc0] = hmrR_MotionCorrectPCArecurse(data_d, probe, mlActMan, tIncMan, tMotion, tMask, STDEVthresh, AMPthresh, nSV, maxIter, turnon)
 
 nBlks = length(data_d);

--- a/FuncRegistry/UserFunctions/hmrR_MotionCorrectRLOESS.m
+++ b/FuncRegistry/UserFunctions/hmrR_MotionCorrectRLOESS.m
@@ -22,6 +22,9 @@
 % span: 0.02
 % turnon: 1
 %
+% PREREQUISITES:
+% Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
+%
 % LOG:
 %
 function data_dod = hmrR_MotionCorrectRLOESS(data_dod, span, turnon)

--- a/FuncRegistry/UserFunctions/hmrR_MotionCorrectSpline.m
+++ b/FuncRegistry/UserFunctions/hmrR_MotionCorrectSpline.m
@@ -32,6 +32,8 @@
 % p: 0.99
 % turnon: 1
 %
+% PREREQUISITES:
+% Motion_Artifact_By_Channel: [tIncAuto, tIncAutoCh] = hmrR_MotionArtifactByChannel(dod, probe, mlActMan, tIncMan, tMotion, tMask, STDEVthresh, AMPthresh)
 % 
 % LOG:
 % created 01-26-2012, J. Selb

--- a/FuncRegistry/UserFunctions/hmrR_MotionCorrectSplineSG.m
+++ b/FuncRegistry/UserFunctions/hmrR_MotionCorrectSplineSG.m
@@ -31,6 +31,9 @@
 % turnon: 1
 %
 % 
+% PREREQUISITES:
+% Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
+%
 % LOG:
 % Sahar Jahani, October 2017
 % Added turn on/off option Meryem Nov 2017

--- a/FuncRegistry/UserFunctions/hmrR_MotionCorrectWavelet.m
+++ b/FuncRegistry/UserFunctions/hmrR_MotionCorrectWavelet.m
@@ -34,6 +34,9 @@
 % iqr: 1.50
 % turnon: 1
 %
+% PREREQUISITES:
+% Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
+%
 % LOG:
 % Script by Behnam Molavi bmolavi@ece.ubc.ca adapted for Homer2 by RJC
 % modified 10/17/2012 by S. Brigadoi

--- a/FuncRegistry/UserFunctions/hmrR_OD2Conc.m
+++ b/FuncRegistry/UserFunctions/hmrR_OD2Conc.m
@@ -29,6 +29,8 @@
 % PARAMETERS:
 % ppf: [1.0, 1.0, 1.0]
 %
+% PREREQUISITES:
+% Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
 function dc = hmrR_OD2Conc( dod, probe, ppf )
 
 dc = DataClass().empty();

--- a/FuncRegistry/UserFunctions/hmrR_PCAFilter.m
+++ b/FuncRegistry/UserFunctions/hmrR_PCAFilter.m
@@ -39,6 +39,10 @@
 % PARAMETERS:
 % nSV: 0.00
 %
+% PREREQUISITES:
+% For the PCA_Filter_Concentration_Data Usage Option, use Delta_OD_to_Conc: dc = hmrR_OD2Conc( dod, probe, ppf )
+% For the PCA_Filter_Delta_OD Usage Option, use Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
+%
 function [data_yc, svs, nSV] = hmrR_PCAFilter( data_y, mlAct, tInc, nSV )
 
 data_yc = DataClass().empty();

--- a/FuncRegistry/UserFunctions/hmrR_StimRejection.m
+++ b/FuncRegistry/UserFunctions/hmrR_StimRejection.m
@@ -8,7 +8,6 @@
 % Excludes stims that fall within the time points identified as
 % motion artifacts from HRF calculation.
 %
-%
 % INPUT:
 % data:     SNIRF data object    
 % stim:     SNIRF stim object
@@ -35,6 +34,10 @@
 % PARAMETERS:
 % tRange: [-5.0, 10.0]
 %
+% PREREQUISITES:
+% Motion_Artifact: tIncAuto = hmrR_MotionArtifact(dod, probe, mlActMan, tIncMan, tMotion, tMask, STDEVthresh, AMPthresh), Motion_Artifact_By_Channel: [tIncAuto, tIncAutoCh] = hmrR_MotionArtifactByChannel(dod, probe, mlActMan, tIncMan, tMotion, tMask, STDEVthresh, AMPthresh)
+%
+
 function [stim, tRange] = hmrR_StimRejection(data, stim, tIncAuto, tIncMan, tRange)
 
 if isempty(tIncAuto)

--- a/FuncRegistry/UserFunctions/tcca_glm/hmrR_tCCA.m
+++ b/FuncRegistry/UserFunctions/tcca_glm/hmrR_tCCA.m
@@ -62,6 +62,10 @@
 % runIdxResting: 1
 % tResting: [30 210]
 %
+% PREREQUISITES:
+% For the hmrR_tCCA_Concentration_Data Usage Option, use Delta_OD_to_Conc: dc = hmrR_OD2Conc( dod, probe, ppf )
+% For the hmrR_tCCA_OD_Data Usage Option, use Intensity_to_Delta_OD: dod = hmrR_Intensity2OD( intensity )
+%
 function [Aaux, rcMap] = hmrR_tCCA(data, aux, probe, runIdx, subjIdx, mlActMan, mlActAuto, flagtCCA, tCCAparams, tCCAaux_inx, rhoSD_ssThresh, ss_ch_on, runIdxResting, tResting)
 
 %% COMMENTS/THOUGHTS/QUESTIONS ALEX

--- a/MainGUI/MainGUI.m
+++ b/MainGUI/MainGUI.m
@@ -453,11 +453,11 @@ if isa(fn_error, 'FuncCallClass')
     l1 = sprintf('The following function: %s', fn_error.nameUI);
     l2 = sprintf('cannot run because of unavailable input(s) %s.', cell2str(missing_args));
     if ~isempty(prereqs)
-       l3 = sprintf('Add one of the following prerequisite functions to the processing stream:\n%s', prereqs)
+       l3 = sprintf('Add one of the following prerequisite functions to the processing stream:\n%s', prereqs);
     else
        l3 = 'Ensure that a function which outputs the necessary inputs appears before the function in the processing stream.'; 
     end
-    err = errordlg({l1, l2, l3}, 'Invalid Processing Stream', 'modal')
+    err = errordlg({l1, l2, l3}, 'Invalid Processing Stream', 'modal');
     return;  % Don't execute if there is an error
 end
 

--- a/MainGUI/MainGUI.m
+++ b/MainGUI/MainGUI.m
@@ -449,8 +449,8 @@ end
 
 % Check the processing stream order
 [fn_error, missing_args, prereqs] = maingui.dataTree.currElem.procStream.Check();
-if fn_error > 0
-    l1 = sprintf('The following function: %s', maingui.dataTree.currElem.procStream.fcalls(fn_error).nameUI);
+if isa(fn_error, 'FuncCallClass')
+    l1 = sprintf('The following function: %s', fn_error.nameUI);
     l2 = sprintf('cannot run because of unavailable input(s) %s.', cell2str(missing_args));
     if ~isempty(prereqs)
        l3 = sprintf('Add one of the following prerequisite functions to the processing stream:\n%s', prereqs)

--- a/MainGUI/MainGUI.m
+++ b/MainGUI/MainGUI.m
@@ -447,6 +447,20 @@ if ~ishandles(hObject)
     return;
 end
 
+% Check the processing stream order
+[fn_error, missing_args, prereqs] = maingui.dataTree.currElem.procStream.Check();
+if fn_error > 0
+    l1 = sprintf('The following function: %s', maingui.dataTree.currElem.procStream.fcalls(fn_error).nameUI);
+    l2 = sprintf('cannot run because of unavailable input(s) %s.', cell2str(missing_args));
+    if ~isempty(prereqs)
+       l3 = sprintf('Add one of the following prerequisite functions to the processing stream:\n%s', prereqs)
+    else
+       l3 = 'Ensure that a function which outputs the necessary inputs appears before the function in the processing stream.'; 
+    end
+    err = errordlg({l1, l2, l3}, 'Invalid Processing Stream', 'modal')
+    return;  % Don't execute if there is an error
+end
+
 MainGUI_EnableDisableGUI(handles,'off');
 
 % Save original selection in listboxGroupTree because it'll change during auto processing 
@@ -463,7 +477,6 @@ try
 catch ME
     MainGUI_EnableDisableGUI(handles,'on');
 	rethrow(ME)
-
 end
       
 % Restore original selection listboxGroupTree


### PR DESCRIPTION
The processing stream will not run if the functions ahead in the stream do not return the necessary input arguments. An error message indicating the offending function will be raised by MainGUI. The PREREQUISITE section of the user function help is implemented in the GUI but not in the registry yet.