### PR TITLE
EditOptionsGUI robustness; errchk support

### DIFF
--- a/DataTree/ProcStream/FuncCallClass.m
+++ b/DataTree/ProcStream/FuncCallClass.m
@@ -608,6 +608,28 @@ classdef FuncCallClass < handle
             end
             nbytes = sum(nbytes);
         end
+
+        % ----------------------------------------------------------------------------------        
+        function errmsg = CheckParams(obj)
+            errmsg = '';
+            paramValStr = '';
+            if exist([obj.name, '_errchk'], 'file')  % If errchk fn is on path
+                for i = 1:length(obj.paramIn)  % Assemble list of args
+                   paramValStr = [paramValStr, obj.paramIn(i).GetFormattedValue()]; %#ok<AGROW>
+                   if i < length(obj.paramIn)
+                       paramValStr = [paramValStr, ',']; %#ok<AGROW>
+                   end
+                end
+                % Call the errchk function which returns a non-empty string
+                % if there is an error
+                eval(['errmsg = ', obj.name, '_errchk(', paramValStr, ')']);
+                if ~isempty(errmsg)
+                   errmsg = [obj.name, ': ', errmsg];
+                end
+            else
+               return;
+            end
+        end
         
     end
 

--- a/DataTree/ProcStream/FuncCallClass.m
+++ b/DataTree/ProcStream/FuncCallClass.m
@@ -327,7 +327,8 @@ classdef FuncCallClass < handle
                             end
                         end
                         pvalue = str2num(textstr{ii+2});                       
-                        obj.paramIn(end+1) = ParamClass(pname, pformat, pvalue);
+                        % Save default values in ParamClass
+                        obj.paramIn(end+1) = ParamClass(pname, pformat, pvalue, pvalue);
                         obj.GetParamHelp(length(obj.paramIn));
                         flag = 2;
                     end

--- a/DataTree/ProcStream/ParamClass.m
+++ b/DataTree/ProcStream/ParamClass.m
@@ -3,6 +3,7 @@ classdef ParamClass < matlab.mixin.Copyable
     properties
         name
         value
+        default
         format
         help
     end
@@ -27,6 +28,11 @@ classdef ParamClass < matlab.mixin.Copyable
                 obj.name   = varargin{1};
                 obj.format = varargin{2};
                 obj.value  = varargin{3};
+            elseif nargin==4
+                obj.name   = varargin{1};
+                obj.format = varargin{2};
+                obj.value  = varargin{3};
+                obj.default = varargin{4};
             end
         end
         
@@ -90,7 +96,12 @@ classdef ParamClass < matlab.mixin.Copyable
         function val = GetFormat(obj)
             val = obj.format;
         end
-                
+
+        % ----------------------------------------------------------------------------------
+        function val = GetDefault(obj)
+            val = obj.default;
+        end
+        
         % ----------------------------------------------------------------------------------
         function str = Encode(obj)
             str = '';

--- a/DataTree/ProcStream/ParamClass.m
+++ b/DataTree/ProcStream/ParamClass.m
@@ -81,6 +81,15 @@ classdef ParamClass < matlab.mixin.Copyable
             end
         end
         
+        % ----------------------------------------------------------------------------------
+        function str = GetFormattedValue(obj)
+            valstr = sprintf(obj.format, obj.value);
+            if length(obj.value) > 1
+                str = ['[', valstr, ']'];
+            else
+                str = valstr;
+            end
+        end
         
         % ----------------------------------------------------------------------------------
         function val = GetName(obj)

--- a/DataTree/ProcStream/ProcStreamClass.m
+++ b/DataTree/ProcStream/ProcStreamClass.m
@@ -190,6 +190,7 @@ classdef ProcStreamClass < handle
         % ----------------------------------------------------------------------------------
         function str = EditParam(obj, iFcall, iParam, val)
             str = '';
+            param = obj.fcalls(iFcall).paramIn(iParam);
             if isempty(iFcall)
                 return;
             end
@@ -202,8 +203,20 @@ classdef ProcStreamClass < handle
             if isempty(obj.fcalls(iFcall).paramIn)
                 return;
             end
-            obj.fcalls(iFcall).paramIn(iParam).value = val;
-            str = sprintf(obj.fcalls(iFcall).paramIn(iParam).format, val);
+            if isprop(param, 'default')
+               default = param.default;
+               if ~isempty(default)
+                   in = val;
+                   val = param.default;
+                   if length(in) > length(default)
+                       val(1:length(default)) = in(1:length(default));
+                   else
+                       val(1:length(in)) = in;                       
+                   end
+               end
+            end
+            str = sprintf(param.format, val);
+            param.value = val;
         end
 
 

--- a/FuncRegistry/UserFunctions/hmrR_GLM.m
+++ b/FuncRegistry/UserFunctions/hmrR_GLM.m
@@ -44,18 +44,15 @@
 %                Defaults: p=8.6 q=0.547
 %                The peak is at time p*q.  The FWHM is about 2.3*sqrt(p)*q.
 % paramsBasis - Parameters for the basis function depends on idxBasis
-%               idxBasis=1 [stdev step] where stdev is the width of the
+%               idxBasis=1 [stdev step ~ ~ ~ ~] where stdev is the width of the
 %                  gaussian and step is the temporal spacing between
 %                  consecutive gaussians
-%               idxBasis=2. [tau sigma T] applied to both HbO and HbR
-%                  or [tau1 sigma1 T1 tau2 sigma2 T2]
-%                  where the 1 (2) indicates the parameters for HbO (HbR).
-%               idxBasis=3 [tau sigma T] applied to both HbO and HbR
-%                  or [tau1 sigma1 T1 tau2 sigma2 T2]
-%                  where the 1 (2) indicates the parameters for HbO (HbR).
-%               idxBasis=4 [p q T] applied to both HbO and HbR
-%                  or [p1 q1 T1 p2 q2 T2]
-%                  where the 1 (2) indicates the parameters for HbO (HbR).
+%               idxBasis=2. [tau1 sigma1 T1 tau2 sigma2 T2] applied to HbO
+%                   and HbR, respectively.
+%               idxBasis=3 [tau1 sigma1 T1 tau2 sigma2 T2] applied to HbO
+%                   and HbR, respectively.
+%               idxBasis=4 [p1 q1 T1 p2 q2 T2] applied to HbO
+%                   and HbR, respectively.
 % rhoSD_ssThresh - max distance for a short separation measurement. Set =0
 %          if you do not want to regress the short separation measurements.
 %          Follows the static estimate procedure described in Gagnon et al (2011).
@@ -252,11 +249,7 @@ for iBlk=1:length(data_y)
         
     elseif idxBasis==2
         % Modified Gamma
-        if length(paramsBasis)==3
-            nConc = 1;
-        elseif length(paramsBasis)==6
-            nConc = 2;
-        end
+        nConc = 2;
         
         nB = 1;
         tbasis = zeros(ntHRF,nB,nConc);

--- a/FuncRegistry/UserFunctions/hmrR_GLM_errchk.m
+++ b/FuncRegistry/UserFunctions/hmrR_GLM_errchk.m
@@ -1,0 +1,19 @@
+% PARAMETERS:
+% trange: [-2.0, 20.0]
+% glmSolveMethod: 1
+% idxBasis: 2
+% paramsBasis: [0.1 3.0 10.0 1.8 3.0 10.0], maxnum: 6
+% rhoSD_ssThresh: 15.0
+% flagNuisanceRMethod: 1
+% driftOrder: 3
+function errmsg = hmrR_GLM_errchk(trange, glmSolveMethod, idxBasis, paramsBasis, rhoSD_ssThresh, flagNuisanceRMethod, driftOrder)
+    errmsg = '';
+    % Define parameter error cases below and return an informative message
+    if idxBasis > 4 || idxBasis < 1
+       errmsg = 'Select a valid basis function (0-4)';
+       return
+    elseif glmSolveMethod > 2 || glmSolveMethod < 1
+       errmsg = 'Select a valid solve method (1-2)'
+       return
+    end
+end

--- a/MainGUI/MainGUI.m
+++ b/MainGUI/MainGUI.m
@@ -433,6 +433,17 @@ end
 
 MainGUI_EnableDisableGUI(handles,'off');
 
+% Check for errchk functions
+fcalls = maingui.dataTree.currElem.procStream.fcalls;
+for iFcall = 1:length(fcalls)
+   errmsg = fcalls(iFcall).CheckParams();
+   if ~isempty(errmsg)
+       errordlg(errmsg, 'Invalid parameters', 'modal');
+       MainGUI_EnableDisableGUI(handles,'on');
+       return
+   end
+end
+
 % Save original selection in listboxGroupTree because it'll change during auto processing 
 val0 = get(handles.listboxGroupTree, 'value');
 

--- a/ProcStreamEditGUI/ProcStreamOptionsGUI.m
+++ b/ProcStreamEditGUI/ProcStreamOptionsGUI.m
@@ -368,7 +368,8 @@ iG = dataTree.GetCurrElemIndexID();
 
 iFcall  = eventdata(1);
 iParam = eventdata(2);
-param = dataTree.currElem.procStream.fcalls(iFcall).paramIn(iParam);
+fcall = dataTree.currElem.procStream.fcalls(iFcall);
+param = fcall.paramIn(iParam);
 val = str2num(get(hObject,'string'));
 
 % If str2num fails or user entered wrong number of params
@@ -377,10 +378,22 @@ if (~isempty(hObject.String) && isempty(val)) || (length(val) > count(param.GetF
     return;
 end
 
+% Edit the parameter
 str = dataTree.currElem.procStream.EditParam(iFcall, iParam, val);
 if isempty(str)
+    set(hObject, 'string', sprintf(param.GetFormat(), hObject.Value));  % Restore og value
     return;
 end
+
+% Check for param errchk function associated with this fcall
+errmsg = fcall.CheckParams();
+if ~isempty(errmsg)
+    set(hObject, 'string', sprintf(param.GetFormat(), hObject.Value));  % Restore og value
+    dataTree.currElem.procStream.EditParam(iFcall, iParam, hObject.Value);  % Restore param in datatree too
+    errordlg(errmsg, 'Invalid parameters', 'modal');
+    return;
+end
+
 set(hObject, 'string', str);
 set(hObject, 'value', str2num(str));  % Actually update the value
 

--- a/ProcStreamEditGUI/ProcStreamOptionsGUI.m
+++ b/ProcStreamEditGUI/ProcStreamOptionsGUI.m
@@ -339,6 +339,7 @@ for k = 1:nFcalls
         eval( sprintf(' fcn = @(hObject,eventdata)ProcStreamOptionsGUI(''edit_Callback'',hObject,[%d %d],guidata(hObject));',k,j) );
         h(end+1,:) = uicontrol(hObject, 'style','edit', 'horizontalalignment','left', 'units','characters', 'position',p(end,:), ...
                                         'string',fcalls(k).GetParamValStr(j), ...
+                                        'value',str2num(fcalls(k).GetParamValStr(j)), ...  % Store current value
                                         'horizontalalignment','center', ...
                                         'Callback',fcn);
     end
@@ -367,13 +368,21 @@ iG = dataTree.GetCurrElemIndexID();
 
 iFcall  = eventdata(1);
 iParam = eventdata(2);
-val = str2num( get(hObject,'string') ); % need to check if it is a valid string
+param = dataTree.currElem.procStream.fcalls(iFcall).paramIn(iParam);
+val = str2num(get(hObject,'string'));
+
+% If str2num fails or user entered wrong number of params
+if (~isempty(hObject.String) && isempty(val)) || (length(val) > count(param.GetFormat(), '%'))
+    set(hObject, 'string', sprintf(param.GetFormat(), hObject.Value));  % Restore og value
+    return;
+end
 
 str = dataTree.currElem.procStream.EditParam(iFcall, iParam, val);
 if isempty(str)
     return;
 end
-set( hObject, 'string', str);
+set(hObject, 'string', str);
+set(hObject, 'value', str2num(str));  % Actually update the value
 
 % Check if we should apply the param edit to all nodes of the current nodes
 % level


### PR DESCRIPTION
EditOptionsGUI is more robust to bad entries. **This feature will not work with old derived data and Registry files.**
- "Default values" found in the help string definition are stored and fallen back on in lieu of user input
- The user CANNOT enter an array parameter with a length different from that of the default array parameter
- hmrR_GLM helpstring updated to reflect that there will **always** be 6 values of paramsBasis. There are potentially more functions that also need a fix/additional docs because of this change.

User function parameter error checking function support
- User function errchk functions are intended to allow developers to give more helpful feedback to users when they enter a bad set of parameters
- Functions with the name `[user function name]_errchk.m`, if found on the path, will be called on parameter edit and before processing stream execution.
- If the errchk functions return a non-empty string, the parameter edit will be reverted/the execution will be aborted, and the string's contents will be displayed to the user along with the name of the offending function
- Demo `hmrR_GLM_errchk.m` function which alerts the user if an invalid idxBasis or glmSolveMethod are entered.