### PR TITLE
Change setpaths to not download submodules by default. Use 'init' or 'update' options to download automatically.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+Group/DataTree merge=ours 
+Utils/Shared merge=ours
+.gitmodules merge=ours

--- a/Install/getRelativePath.m
+++ b/Install/getRelativePath.m
@@ -1,0 +1,16 @@
+function path3 = getRelativePath(path1, path2)
+path3 = '';
+path1 = filesepStandard_startup(path1);
+path2 = filesepStandard_startup(path2);
+
+k = strfind(path1, path2);
+if isempty(k) %#ok<*STREMP>
+    return
+end
+if ispathvalid(path1, 'dir')
+    j = 1;
+else
+    j = 0;
+end
+path3 = path1(length(path2)+1:end-j);
+

--- a/Install/myCopyFile.m
+++ b/Install/myCopyFile.m
@@ -1,0 +1,143 @@
+function myCopyFile(src, dst)
+global logger %#ok<NUSED>
+global h
+global iStep
+global nSteps
+
+if nargin==0
+    src = '';
+    dst = '';
+end
+if nargin==1
+    dst = '';
+end
+if ~ispathvalid(src)
+    if ~ispathvalid([src, '.gz'])
+        if ~ispathvalid([src, 'tar.gz'])
+            if ~ispathvalid([src, '.zip'])
+                if ~ispathvalid([src, '.tar'])
+                    return
+                end
+            end
+        end
+    end
+end
+
+printFuncName = getStandardOutputFuncName();
+
+[~,f,e] = fileparts(src);
+if (isempty(f) || strcmp(f, '.')) && strcmp(e, '.')
+    return;
+end
+
+src = filesepStandard(src, 'full');
+dst = filesepStandard(dst, 'full:nameonly');
+
+
+files = dir(src);
+
+for ii = 1:length(files)
+    if strcmp(files(ii).name, '.') || strcmp(files(ii).name, '..')
+        continue;
+    end
+    
+    % Set full path names of source and destination
+    srcNew = unpack([filesepStandard(files(ii).folder), files(ii).name]);
+    [~, f, e] = fileparts(srcNew);
+    if ~strcmp(files(ii).name, [f,e])
+        eval( sprintf('%s(''Skipping %%s\\n'', [filesepStandard(files(ii).folder), files(ii).name]);', printFuncName) );        
+        files(ii).name = [f,e];
+    end
+    
+    % Rules for copying
+    if ispathvalid(srcNew,'dir')
+        dstNew = [dst, '/', files(ii).name];
+        if ~ispathvalid(dstNew)
+            try
+            mkdir(dstNew)
+            catch
+                d=1;
+            end
+        end
+        myCopyFile(srcNew, dstNew);
+    elseif ispathvalid(srcNew,'file')
+        if ispathvalid(dst, 'dir')
+            dstNew = [dst, '/', files(ii).name];
+        elseif ispathvalid(src, 'dir')
+            dstNew = [dst, '/', files(ii).name];
+            mkdir(dst)
+        else
+            dstNew = dst;
+            dstRoot = fileparts(dst);
+            if ~ispathvalid(dstRoot)
+                mkdir(dstRoot)
+            end
+        end
+        try
+            if ispathvalid(dstNew)
+                return
+            end
+            eval( sprintf('%s(''Copying  %%s   to   %%s\\n'', srcNew, dstNew);', printFuncName) );
+            copyfile(srcNew, dstNew);
+            if ~isempty(iStep)
+                if ishandles(h)
+                    waitbar(iStep/nSteps, h);
+                end
+                iStep = iStep+1;
+            end            
+        catch ME
+            printStack(ME);
+        end
+    else
+        eval( sprintf('%s(''WARNING: Path %%s does not exist\\n'', srcNew);', printFuncName) );
+    end
+end
+pause(.7)
+
+
+
+% ----------------------------------------------------------------------
+function [src, ext] = unpack(src)
+[pname1, fname1, ext1] = fileparts(src);
+[~, ~, ext2] = fileparts(fname1);
+ext = [ext2, ext1];
+temp = [pname1, '/temp/'];
+if ispathvalid(temp)
+    rmdir(temp,'s');
+end
+switch(ext)
+    case '.tar'
+        mkdir(temp);
+        untar(src, temp);
+    case '.tar.gz'
+        mkdir(temp);
+        untar(src, temp);
+    case '.gz'
+        mkdir(temp);
+        gunzip(src, temp);
+    case '.zip'
+        mkdir(temp);
+        unzip(src, temp);
+    otherwise
+        return
+end
+
+f = dir([temp, '/*']);
+for ii = 1:length(f)
+    if strcmp(f(ii).name,'.')
+        continue;
+    end
+    if strcmp(f(ii).name,'..')
+        continue;
+    end
+    if ~ispathvalid([pname1, '/', f(ii).name])
+        copyfile([temp, '/', f(ii).name], pname1)
+        break;
+    end
+end
+if ispathvalid(temp)
+    rmdir(temp,'s');
+end    
+src = [pname1, '/', f(ii).name];
+
+

--- a/Utils/getVernum.m
+++ b/Utils/getVernum.m
@@ -20,7 +20,7 @@ function [vrnnum] = getVernum_AtlasViewerGUI()
 
 vrnnum{1} = '2';   % Major version #
 vrnnum{2} = '16';  % Major sub-version #
-vrnnum{3} = '0';   % Minor version #
+vrnnum{3} = '1';   % Minor version #
 vrnnum{4} = '0';   % Minor sub-version # or patch #: 'p1', 'p2', etc
 
 

--- a/Utils/submodules/downloadSharedLibs.m
+++ b/Utils/submodules/downloadSharedLibs.m
@@ -8,6 +8,10 @@ if ~exist('options','var') || (isnumeric(options) && options==0)
 end
 
 s = parseGitSubmodulesFile();
+if ~optionExists_startup(options,'init') && ~optionExists_startup(options,'update') 
+    addSearchPaths(s);
+    return;
+end
 
 % Check for missing libs
 kk = checkMissingLibraries(s);
@@ -77,10 +81,10 @@ msg{ii} = sprintf('Git was not able to install the following libraries required 
 for jj = 1:size(s,1)
     msg{ii} = sprintf('    %s\n', s{jj,1}); ii = ii+1;
 end
-msg{ii} = sprintf('\n'); ii = ii+1; %#ok<SPRINTFN>
+msg{ii} = sprintf('\n'); ii = ii+1;
 msg{ii} = sprintf('Git might not be installed on your computer. \n'); ii = ii+1;
 msg{ii} = sprintf('These libraries can still be installed without git. The assumed submodule branch that matches \n'); ii = ii+1;
-msg{ii} = sprintf('the branch of the parent repo, ''%s'', is ''%s''\n\n', appname, branch); ii = ii+1;
+msg{ii} = sprintf('the branch of the parent repo, ''%s'', is ''%s''\n\n', appname, branch); ii = ii+1; %#ok<NASGU>
 msg = [msg{:}];
 
 fprintf(msg)
@@ -95,7 +99,7 @@ msg{ii} = sprintf('WARNING: The following libraries required by this application
 for jj = 1:size(s,1)
     msg{ii} = sprintf('    %s\n', s{jj,1}); ii = ii+1;
 end
-msg{ii} = sprintf('\n'); ii = ii+1;
+msg{ii} = sprintf('\n'); ii = ii+1; %#ok<*SPRINTFN>
 msg{ii} = sprintf('Either a) install git and rerun setpaths or b) download the submodules manually and provide their locations. '); ii = ii+1;
 msg{ii} = sprintf('Select option:');
 msg = [msg{:}];
@@ -107,7 +111,6 @@ q = menu(msg, {'Quit setpaths, install git and rerun setpaths','Download submodu
 
 % ----------------------------------------------------------
 function addSearchPaths(s)
-kk = [];
 exclSearchList  = {'.git'};
 for ii = 1:size(s,1)
     foo = findDotMFolders(s{ii,3}, exclSearchList);
@@ -123,7 +126,7 @@ end
 % ---------------------------------------------------
 function setpermissions(appPath)
 if isunix() || ismac()
-    if ~isempty(strfind(appPath, '/bin'))
+    if ~isempty(strfind(appPath, '/bin')) %#ok<STREMP>
         fprintf(sprintf('chmod 755 %s/*\n', appPath));
         files = dir([appPath, '/*']);
         if ~isempty(files)
@@ -158,7 +161,6 @@ fprintf('\nBranch guess:  ''%s''\n', branchGuess);
 % Check to see if submodule urls exist. If not edfault to 'master' branches. 
 for ii = 1:size(submodules,1)
     url             = submodules{ii,1};
-    submodulepath   = submodules{ii,3};
     
     urlfull = sprintf('%s/archive/refs/heads/%s.zip', url, branchGuess);
     [~, urlExists] = urlread(urlfull); %#ok<*URLRD>

--- a/Utils/submodules/findAllFiles.m
+++ b/Utils/submodules/findAllFiles.m
@@ -1,8 +1,12 @@
-function files = findAllFiles(subdir)
+function files = findAllFiles(subdir, pattern)
 files = {};
 if ~exist('subdir','var')
     subdir = pwd;
 end
+if ~exist('pattern','var')
+    pattern = '*';
+end
+
 if ~ispathvalid_startup(subdir, 'dir')
     fprintf('Warning: folder %s doesn''t exist under %s\n', subdir, pwd);
     return;
@@ -20,9 +24,11 @@ for ii = 1:length(f)
     end
     
     if ~f(ii).isdir
-        files{end+1,1} = filesepStandard_startup(sprintf('%s%s%s', subdirFullpath, f(ii).name), 'nameonly');         %#ok<*AGROW>
+        if strcmp(pattern,'*') || strcmp(f(ii).name, pattern) 
+        	files{end+1,1} = filesepStandard_startup(sprintf('%s%s%s', subdirFullpath, f(ii).name), 'nameonly');         %#ok<*AGROW>
+        end
     else
-        files = [files; findAllFiles([subdirFullpath, f(ii).name])];
+        files = [files; findAllFiles([subdirFullpath, f(ii).name], pattern)];
     end
 end
 

--- a/Utils/submodules/gitSubmodulesInit.m
+++ b/Utils/submodules/gitSubmodulesInit.m
@@ -16,20 +16,26 @@ end
 repoFull = filesepStandard_startup(repo,'full');
 ii = 1;
 
+submodules = parseGitSubmodulesFile(repoFull);
+url = gitGetOrigin(repoFull);
+urlroot = fileparts(url);
+
 cmds{ii,1} = sprintf('cd %s', repoFull); ii = ii+1;
 cmds{ii,1} = sprintf('git config --global http.sslverify "false"'); ii = ii+1;
-cmds{ii,1} = sprintf('git submodule update --init'); ii = ii+1; %#ok<NASGU>
+for jj = 1:size(submodules,1)
+    [~, submodulename] = fileparts(submodules{jj,1});
+    if ~strcmp(submodules{jj,1}, [urlroot, '/', submodulename])
+        cmds{ii,1} = sprintf('git config --file=.gitmodules submodule.%s.url %s', submodules{jj,3}(1:end-1), [urlroot, '/', submodulename]); ii = ii+1;
+    end
+end
+cmds{ii,1} = sprintf('git submodule update --init --recursive --remote'); ii = ii+1;
 
 [errs, msgs] = exeShellCmds(cmds, preview);
 
-submodules = parseGitSubmodulesFile(repo);
-
 % Set origin for submodules to be same as origin for parent repo
-url = gitGetOrigin(repoFull);
-urlroot = fileparts(url);
-for ii = 1:size(submodules,1)
-    [~, submodulename] = fileparts(submodules{ii,1});
-    gitSetOrigin([repoFull, submodules{ii,3}], [urlroot, '/', submodulename]);
+for kk = 1:size(submodules,1)
+    [~, submodulename] = fileparts(submodules{kk,1});
+    gitSetOrigin([repoFull, submodules{kk,3}], [urlroot, '/', submodulename]);
 end
 
 % Checkout branch for parent repo and submodules. First checkout the source

--- a/setpaths.m
+++ b/setpaths.m
@@ -18,25 +18,24 @@ function setpaths(options)
 %
 %   options:
 %        1. no arguments
-%           Add search paths for parent app under current folder and all its associated submodules. Initialize
-%           all submodules to same branch and origin as parent app equivalent to numeric argument 1 or string
-%           argument 'init'.
+%           Add search paths for parent app under current folder and all its associated submodules. 
+%           It is equivalent to argument value of 1. NOTE: This option will NOT automatically 
+%           download submodules. (See 'init' or 'update' options)
 %
 %        2. 1
-%           Add search paths for parent app under current folder and all its associated submodules. Initialize all
-%           submodules to same branch and origin as parent app equivalent to string argument 'init' or no arguments
+%           Add search paths for parent app under current folder and all its associated submodules. NOTE: 
+%           This option will NOT automatically download submodules. (See 'init' or 'update' options)
 %
 %        3. 0
 %           Remove search paths for parent app under current folder and all its associated submodules
 %
 %        4. 'init'
-%           Add search paths for parent app under current folder and all its associated submodules. Initialize all
-%           submodules to same branch and origin as parent app equivalent to numeric argument 1 or no arguments
+%           Add search paths for parent app under current folder and all its associated submodules. Initialize
+%           all submodules to same branch and origin as parent app
 %
 %        5. 'update'
 %           Update all submodules to their latest revision for their current branches. If used on a newly
-%           downloaded parent app it will do the equivalent of setpaths with no args, setpaths('init')
-%           or setpaths(1).
+%           downloaded parent app it will do the equivalent of setpaths('init').
 %
 %        6. 'branch: <branchname>'
 %           Add search paths for parent app under current folder and all its associated submodules. Initialize all
@@ -96,12 +95,12 @@ try
     % Parse arguments
     addremove = 1;
     if ~exist('options','var')
-        options = 'init';
+        options = '';
     elseif isnumeric(options)
         if options == 0
             addremove = 0;
         else
-            options = 'init';
+            options = '';
         end
     end
     
@@ -120,7 +119,7 @@ try
     appThis         = filesepStandard_startup(pwd);
     appThisPaths    = findDotMFolders(appThis, exclSearchList);
     if addremove == 0
-        if exist([pwd, '/Utils/namespace'],'dir')
+        if ~isempty(which('deleteNamespace.m'))
             deleteNamespace(appname);
         end
         removeSearchPaths(appThis);
@@ -178,8 +177,10 @@ try
         fprintf('ERROR: Could not download shared libraries required by this application...\n')
         return;
     end
-    setNamespace(appname);
     
+    if ~isempty(which('setNamespace.m'))
+        setNamespace(appname);
+    end
     
     % Add back all search paths for all other apps except for current app
     for ii = 1:length(appInclList)
@@ -191,7 +192,7 @@ try
         addSearchPaths(foo);
     end
     
-    if exist([pwd, '/Utils/Shared/setpaths_proprietary.m'],'file')
+    if  ~isempty(which('setpaths_proprietary.m'))
         setpaths_proprietary(options);
     end
     


### PR DESCRIPTION
-- Change setpaths to not download submodules by default. Use 'init' or 'update' options to download automatically. If using github desktop then github desktop download submodules automatically.
-- Change downloadSharedLibs to change .gitmodules origin url to point to where ever parent came from
-- Add .gitattributes to exclude files from branch merges such as submodule references and .gitmodules
-- Sync getVernum with Homre3. (getVernum will eventually be moved to Utils/Shared library)
-- Improve creation of installation file and installation process using myCopyFile.m
