### PR TITLE
fix(snirf): remove additional argument

### DIFF
--- a/DataTree/AcquiredData/DataFiles/Hdf5/hdf5write_safe.m
+++ b/DataTree/AcquiredData/DataFiles/Hdf5/hdf5write_safe.m
@@ -55,7 +55,7 @@ function err = hdf5write_safe(fname, name, val, options)
         return
     elseif isinteger(val)
         if length(val) > 1 && ~force_scalar || force_array
-            write_numeric_array(fid, fname, name, val);  % As of now, no integer arrays exist
+            write_numeric_array(fname, name, val);  % As of now, no integer arrays exist
         else
             write_integer(fid, fname, name, val);
         end


### PR DESCRIPTION
## What

The `write_numeric_array` function was being passed 4 arguments when it only takes 3. Presumably this was related to a mix up with `write_numeric` which takes 4 arguments.

This would lead to the following error when calling `SaveHdf5` on a `SnirfClass` object.

```
Error using hdf5write_safe>write_numeric_array
Too many input arguments.

Error in hdf5write_safe (line 58)
            write_numeric_array(fid, fname, name, val);  % As of now, no integer arrays exist

Error in DataClass/SaveHdf5 (line 250)
            hdf5write_safe(fileobj, [location, '/time'], obj.time, 'array');

Error in SnirfClass/SaveData (line 667)
                obj.data(ii).SaveHdf5(fileobj, [obj.location, '/data', num2str(ii)]);

Error in SnirfClass/SaveHdf5 (line 728)
            obj.SaveData(fileobj);
```