### PR TITLE
Fix for sniff conversion & Check if namespace function exists, if not run setpaths

### DIFF
--- a/DataTree/AcquiredData/DataFiles/Hdf5/hdf5write_safe.m
+++ b/DataTree/AcquiredData/DataFiles/Hdf5/hdf5write_safe.m
@@ -98,7 +98,7 @@ warning off;  % Suppress the int truncation warning
 tid = H5T.copy('H5T_NATIVE_ULONG');
 sid = H5S.create('H5S_SCALAR');
 dsid = H5D.create(fid, name, tid, sid, 'H5P_DEFAULT');
-H5D.write(dsid, tid, 'H5S_ALL', 'H5S_ALL', 'H5P_DEFAULT', int32(val));
+H5D.write(dsid, tid, 'H5S_ALL', 'H5S_ALL', 'H5P_DEFAULT', uint64(val));
 err = 0;
 warning on;
 

--- a/Homer3.m
+++ b/Homer3.m
@@ -12,6 +12,14 @@ function unitTest = Homer3(groupDirs, inputFileFormat, unitTest)
 global logger
 global cfg
 
+
+% Check if namespace loaded (proxy for setpaths being initialized)
+namespaceLoaded = exist('setNamespace','file');
+
+if(~namespaceLoaded)
+    setpaths();
+end
+
 setNamespace('Homer3');
 
 if ~exist('groupDirs','var') || isempty(groupDirs)


### PR DESCRIPTION
Namespace function will not run unless setpaths has been initialized (or is already included in the homer3 directories). Checking here will allow users to directly run homer3 without first setting paths