### PR TITLE
quite mode and stimClass

### DIFF
--- a/DataTree/AcquiredData/Snirf/StimClass.m
+++ b/DataTree/AcquiredData/Snirf/StimClass.m
@@ -459,7 +459,7 @@ classdef StimClass < FileLoadSaveClass
                 amp = ones(length(tPts),1);
             end
             if ~exist('more', 'var')
-               more = [];
+               more = 1;
             end
             
             if length(duration) < length(tPts)

--- a/DataTree/AppSettings.cfg
+++ b/DataTree/AppSettings.cfg
@@ -38,7 +38,7 @@ No
 No
 
 % Quiet Mode # On, Off
-Off
+On
 
 % Replace TSV File Tabs with Spaces # auto-replace, ask me, don't replace and don't ask me
 ask me


### PR DESCRIPTION
Changed the default mode to quite mode on.
Changed StimClass default value of "more" to 1 from []. [] wasa breaking the code at line 471:
"            obj.data = [obj.data; tPts, duration, amp, more];"