### PR TITLE
fix plotprob2 bugs 1)typo 2)conditions mismatch error

### DIFF
--- a/MainGUI/MainGUI.m
+++ b/MainGUI/MainGUI.m
@@ -884,7 +884,7 @@ global maingui
 LaunchChildGuiFromMenu('PlotProbeGUI', hObject, GetDatatype(handles), maingui.condition);
 
 % --------------------------------------------------------------------
-function menuItemPlotProbe2_Callback(hObject, ~, handles)
+function menuItemPlotProbe2GUI_Callback(hObject, ~, handles)
 global maingui
 procElem = maingui.dataTree.currElem;
 % Derived data that we want to save in a Snirf file.
@@ -917,7 +917,7 @@ elseif strcmp(procElem.type,'group')
     maingui.dataTree.LoadCurrElem()
 end
 probe = procElem.acquired.probe;
-stim = procElem.acquired.stim;
+stim = procElem.procStream.input.acquired.stim;
 metaDataTags = procElem.acquired.metaDataTags;
 
 obj = SnirfClass(data, stim, probe, metaDataTags);


### PR DESCRIPTION
Fixed couple of bugs in plotprobe2
1) typo
2) plotprobe2 was displaying conditions incorrectly. It is fixed now.