### PR TITLE
Critical bug fix SplineSG mlAct

### DIFF
--- a/FuncRegistry/UserFunctions/Archive/hmrR_BandpassFilt_Nirs.m
+++ b/FuncRegistry/UserFunctions/Archive/hmrR_BandpassFilt_Nirs.m
@@ -42,26 +42,19 @@ FilterOrder = 3;
 %[fa,fb]=butter(FilterOrder,lpf*2/fs);
 if FilterType==1 | FilterType==5
     [fb,fa] = MakeFilter(FilterType,FilterOrder,fs,lpf,'low');
-elseif FilterType==4
-%    [fb,fa] = MakeFilter(FilterType,FilterOrder,fs,lpf,'low',Filter_Rp,Filter_Rs);
-else
-%    [fb,fa] = MakeFilter(FilterType,FilterOrder,fs,lpf,'low',Filter_Rp);
 end
 ylpf=filtfilt(fb,fa,y);
 
+y2 = ylpf;
+
 % high pass filter
+if hpf ~= 0
 FilterType = 1;
 FilterOrder = 5;
 if FilterType==1 | FilterType==5
     [fb,fa] = MakeFilter(FilterType,FilterOrder,fs,hpf,'high');
-elseif FilterType==4
-%    [fb,fa] = MakeFilter(FilterType,FilterOrder,fs,hpf,'high',Filter_Rp,Filter_Rs);
-else
-%    [fb,fa] = MakeFilter(FilterType,FilterOrder,fs,hpf,'high',Filter_Rp);
+end
+y2=filtfilt(fb,fa,ylpf); 
 end
 
-if FilterType~=5
-    y2=filtfilt(fb,fa,ylpf); 
-else
-    y2 = ylpf;
-end
+

--- a/FuncRegistry/UserFunctions/Archive/hmrR_MotionCorrectSpline_Nirs.m
+++ b/FuncRegistry/UserFunctions/Archive/hmrR_MotionCorrectSpline_Nirs.m
@@ -55,6 +55,8 @@ dtLong  = 3;    % seconds
 ml = SD.MeasList;
 mlAct = SD.MeasListAct; % prune bad channels
 
+mlAct = [mlAct; mlAct]; % hardcoded fix to include two wavelengths
+
 lstAct = find(mlAct==1);
 dodSpline = dod;
 t = t(:);  % needs to be a column vector


### PR DESCRIPTION
* SplineSG has mlActAuto as an input. Due to the changes in homer3, mlActAuto contains only the first wavelength. SplineSG thus failed to clean the data from the second wavelength. 
      Note for homer2 users: This was working properly for homer2. 
      Note for homer3 users: Please reconsider running your pipeline with this version and up.
* Cleaned up code -> now no warning re filter parameters empty.

