### PR TITLE
make filesepStandard_startup compatible with \\ at beginning

### DIFF
--- a/FuncRegistry/UserFunctions/hmrR_BlockAvg.m
+++ b/FuncRegistry/UserFunctions/hmrR_BlockAvg.m
@@ -73,7 +73,7 @@ for kk=1:length(data)
         yblk = zeros(nPost-nPre+1,size(y,2),size(y,3),size(s,2));
     elseif strcmp(datatype{1}, 'dOD')
         ml = data(kk).GetMeasList('reshape');
-        yblk = zeros(nPost-nPre+1,size(y,2),size(y,3),size(s,2));
+        yblk = zeros(nPost-nPre+1,size(y,2),size(s,2));
     else
         return;
     end
@@ -88,7 +88,7 @@ for kk=1:length(data)
                     yblk(:,:,:,nBlk) = y(lstS(iT)+[nPre:nPost],:,:); %changed from yblk(:,:,:,end+1)
                 elseif strcmp(datatype{1}, 'dOD')
                     nBlk = nBlk + 1;
-                    yblk(:,:,:,nBlk) = y(lstS(iT)+[nPre:nPost],:,:); % changd from yblk(:,:,end+1)
+                    yblk(:,:,nBlk) = y(lstS(iT)+[nPre:nPost],:); % changd from yblk(:,:,end+1)
                 end
             else
                 fprintf('WARNING: Trial %d for Condition %d EXCLUDED because of time range\n',iT,iC);
@@ -133,35 +133,31 @@ for kk=1:length(data)
             data_std(kk).AppendDataTimeSeries(ystd(:,:,:,iC));
             data_sum2(kk).AppendDataTimeSeries(ysum2(:,:,:,iC));
         elseif strcmp(datatype{1}, 'dOD')
-            yTrials(iC).yblk = yblk(:,:,:,1:nBlk);
-            yavg(:,:,:,iC) = mean(yblk(:,:,:,1:nBlk),4);
-            ystd(:,:,:,iC) = std(yblk(:,:,:,1:nBlk),[],4);
+            yTrials(iC).yblk = yblk(:,:,1:nBlk);
+            yavg(:,:,iC) = mean(yblk(:,:,1:nBlk),3);
+            ystd(:,:,iC) = std(yblk(:,:,1:nBlk),[],3);
             nTrials{kk}(iC) = nBlk;
 
-            % Loop over all channels
-            for ii=1:size(yavg,3)
-                foom = ones(size(yavg,1),1)*mean(yavg(1:-nPre,:,ii,iC),1);
-                yavg(:,:,ii,iC) = yavg(:,:,ii,iC) - foom;
+            % Loop over all wavelengths
+            for ii=1:size(yavg,2)
+                foom = ones(size(yavg,1),1)*mean(yavg(1:-nPre,ii,iC),1);
+                yavg(:,ii,iC) = yavg(:,ii,iC) - foom;
                 
                 for iBlk = 1:nBlk
-                    yTrials(iC).yblk(:,:,ii,iBlk) = yTrials(iC).yblk(:,:,ii,iBlk) - foom;
+                    yTrials(iC).yblk(:,ii,iBlk) = yTrials(iC).yblk(:,ii,iBlk) - foom;
                 end
-                ysum2(:,:,ii,iC) = sum( yTrials(iC).yblk(:,:,ii,1:nBlk).^2 ,4);
+                ysum2(:,ii,iC) = sum( yTrials(iC).yblk(:,ii,1:nBlk).^2 ,3);
 
                 % Snirf stuff: set channel descriptors
-                data_avg(kk).AddChannelDod(ml((ii-1)*2+1,1), ml((ii-1)*2+1,2), ml((ii-1)*2+1,4), iC);
-                data_std(kk).AddChannelDod(ml((ii-1)*2+1,1), ml((ii-1)*2+1,2), ml((ii-1)*2+1,4), iC);
-                data_sum2(kk).AddChannelDod(ml((ii-1)*2+1,1), ml((ii-1)*2+1,2), ml((ii-1)*2+1,4), iC);
-
-                data_avg(kk).AddChannelDod(ml(ii*2,1), ml(ii*2,2), ml(ii*2,4), iC);
-                data_std(kk).AddChannelDod(ml(ii*2,1), ml(ii*2,2), ml(ii*2,4), iC);
-                data_sum2(kk).AddChannelDod(ml(ii*2,1), ml(ii*2,2), ml(ii*2,4), iC);
+                data_avg(kk).AddChannelDod(ml(ii,1), ml(ii,2), ml(ii,4), iC);
+                data_std(kk).AddChannelDod(ml(ii,1), ml(ii,2), ml(ii,4), iC);
+                data_sum2(kk).AddChannelDod(ml(ii,1), ml(ii,2), ml(ii,4), iC);
             end
             
             % Snirf stuff: set data vectors
-            data_avg(kk).AppendDataTimeSeries(yavg(:,:,:,iC));
-            data_std(kk).AppendDataTimeSeries(ystd(:,:,:,iC));
-            data_sum2(kk).AppendDataTimeSeries(ysum2(:,:,:,iC));
+            data_avg(kk).AppendDataTimeSeries(yavg(:,:,iC));
+            data_std(kk).AppendDataTimeSeries(ystd(:,:,iC));
+            data_sum2(kk).AppendDataTimeSeries(ysum2(:,:,iC));
         end
     end
     

--- a/Utils/Shared/filesepStandard.m
+++ b/Utils/Shared/filesepStandard.m
@@ -49,7 +49,9 @@ if ischar(pathname0)
     idxs = [];        
     k = find(pathname0=='\' | pathname0=='/');
     for ii = 1:length(k)
-        if (ii>1) && (k(ii) == k(ii-1)+1)
+        if (ii>1) && (k(ii) == k(ii-1)+1) && (k(ii) > 2)
+            % adjacent two values are same, and the values are not the
+            % first two characters (for paths like \\ad\eng\ ...)
             idxs = [idxs, k(ii)]; %#ok<AGROW>
             continue;
         end

--- a/Utils/submodules/filesepStandard_startup.m
+++ b/Utils/submodules/filesepStandard_startup.m
@@ -50,9 +50,10 @@ if ischar(pathname0)
     idxs = [];        
     k = find(pathname0=='\' | pathname0=='/');
     for ii = 1:length(k)
-        if (ii>1) && (k(ii) == k(ii-1)+1)
+        if (ii>1) && (k(ii) == k(ii-1)+1) && (k(ii) > 2)
+            % adjacent two values are same, and the values are not the
+            % first two characters (for paths like \\ad\eng\ ...)
             idxs = [idxs, k(ii)]; %#ok<AGROW>
-            continue;
         end
         pathname0(k(ii)) = '/';
     end

--- a/setpaths.m
+++ b/setpaths.m
@@ -577,9 +577,10 @@ if ischar(pathname0)
     idxs = [];        
     k = find(pathname0=='\' | pathname0=='/');
     for ii = 1:length(k)
-        if (ii>1) && (k(ii) == k(ii-1)+1)
+        if (ii>1) && (k(ii) == k(ii-1)+1) && (k(ii) > 2)
+            % adjacent two values are same, and the values are not the
+            % first two characters (for paths like \\ad\eng\ ...)
             idxs = [idxs, k(ii)]; %#ok<AGROW>
-            continue;
         end
         pathname0(k(ii)) = '/';
     end


### PR DESCRIPTION
Some directories (like university server ones) use double backslash or forward slash at the beginning. e.g. \\\ad\eng\users\....

Added exception to removing double+ slashes at the very beginning for filesepStandard_startup functions both in setpaths and in Utils.