### PR TITLE
fix obj revesion date number error in FileClass.m

### DIFF
--- a/DataTree/AcquiredData/DataFiles/FileClass.m
+++ b/DataTree/AcquiredData/DataFiles/FileClass.m
@@ -90,7 +90,7 @@ classdef FileClass < matlab.mixin.Copyable
             obj.name         = getPathRelative(rootpath, obj2.rootdir);
             obj.rootdir 	 = obj2.rootdir;
             obj.date         = obj2.date;
-            obj.datenum      = datestr2datenum(obj.date);
+            obj.datenum      = obj2.datenum;
             if obj.IsFile()
                 obj.err          = obj.errcodeUnvalidated;          % Set error to unvalidated
             else


### PR DESCRIPTION
For the locale different from en_US on Windows and Mac, the date format return by dir() function is not recognized by datetime. However the dir() will return datenum, no need to use another function to convert it from string.